### PR TITLE
Allow item_name-only prediction() requests

### DIFF
--- a/main.py
+++ b/main.py
@@ -27,7 +27,7 @@ class PredictionRequest(BaseModel):
     max_price: float
     item_names: List[str]
     retailers: List[str]
-    use_entire_brand: bool = False
+    use_entire_brand: bool = True
 
 
 class DataSeries(BaseModel):


### PR DESCRIPTION
Changed the prediction() endpoint to take an optional argument use_entire_brand to determine whether to only aggregate past and predicted promos for entire brand of given items, or only the given items.

This allows merchiq_consumer to get promo data for only certain items, while allowing merchiq to continue to get this data aggregated by brand.

Previous behavior always returned promo data for entire brands of given item_name values.